### PR TITLE
Fix Password encryption when creating the first account

### DIFF
--- a/src/Commands/QuickAdminInstall.php
+++ b/src/Commands/QuickAdminInstall.php
@@ -84,7 +84,7 @@ class QuickAdminInstall extends Command
     {
         $data['name']     = $this->ask('Administrator name');
         $data['email']    = $this->ask('Administrator email');
-        $data['password'] = $this->secret('Administrator password');
+        $data['password'] = bcrypt($this->secret('Administrator password'));
         $data['role_id']  = 1;
         User::create($data);
         $this->info('User has been created');


### PR DESCRIPTION
When creating the first account, the password is inserted as plain text, and logging in does not work. Can't confirm if that happens when managing users from the admin.