### PR TITLE
fix possible broken install due to 'not null' constraint error

### DIFF
--- a/src/Migrations/2015_10_10_000000_create_menus_table
+++ b/src/Migrations/2015_10_10_000000_create_menus_table
@@ -14,7 +14,7 @@ class CreateMenusTable extends Migration
     {
         Schema::create('menus', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('position');
+            $table->integer('position')->nullable();
             $table->integer('menu_type')->default(1);
             $table->string('icon')->nullable();
             $table->string('name')->unique();


### PR DESCRIPTION
added nullable() to position column because it can cause error thrown during install when Menu::create() is called from QuickAdminInstall