### PR TITLE
Fixed ReflectionException

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -24,7 +24,7 @@ if (Schema::hasTable('menus')) {
                             'uses' => 'Admin\\' . ucfirst(camel_case($menu->name)) . 'Controller@massDelete'
                         ]);
                         Route::resource(strtolower($menu->name),
-                            'Admin\\' . ucfirst(camel_case($menu->name)) . 'Controller');
+                            'Admin\\' . ucfirst(camel_case($menu->name)) . 'Controller', ['except' => 'show']);
                         break;
                     case 3:
                         Route::controller(strtolower($menu->name),


### PR DESCRIPTION
When you try to visit the show method for a CRUD controller, the ReflectionException was thrown.
Simple fix by adding the `except` parameter for registering a resource controller.