### PR TITLE
Update composer.json, conflict with minimum-stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "version": "2.1.0",
   "require": {
-    "laravel/framework": "5.3.*",
+    "laravel/framework": "5.4.*",
     "laravelcollective/html": "^5.3",
     "intervention/image": "^2.3",
     "yajra/laravel-datatables-oracle": "^6.18"


### PR DESCRIPTION
Need 5.4 to avoid this error:

`laraveldaily/quickadmin 2.1.0 requires laravel/framework 5.3.* -> satisfiable by laravel/framework[5.3.x-dev, v5.3.0, v5.3.0-RC1, v5.3.1, v5.3.10, v5.3.11, v5.3.12, v5.3.13, v5.3.14, v5.3.15, v5.3.16, v5.3.17, v5.3.18, v5.3.19, v5.3.2, v5.3.20, v5.3.21, v5.3.22, v5.3.23, v5.3.24, v5.3.25, v5.3.26, v5.3.27, v5.3.28, v5.3.29, v5.3.3, v5.3.30, v5.3.4, v5.3.5, v5.3.6, v5.3.7, v5.3.8, v5.3.9] but these conflict with your requirements or minimum-stability.`
